### PR TITLE
Remove replica settings

### DIFF
--- a/web-settings.php
+++ b/web-settings.php
@@ -9,8 +9,3 @@
     static $oauth_consumer_key = getenv('OAUTH_KEY');
     static $oauth_consumer_secret = getenv('OAUTH_SECRET');
 
-    static $mw_mysql_host = 'enwiki.labsdb';
-    static $mw_mysql_port = 3306;
-    static $mw_mysql_user = getenv('TOOL_REPLICA_USER');
-    static $mw_mysql_pass = getenv('TOOL_REPLICA_PASSWORD');
-    static $mw_mysql_schema = 'enwiki_p';


### PR DESCRIPTION
These where used in the api for providing training data, that logic was
pulled out into the api repo and then deprecated.
